### PR TITLE
Temporary - for testing Remove slidding Expiration of cache 

### DIFF
--- a/Pokedex.Api/Framework/CacheService.cs
+++ b/Pokedex.Api/Framework/CacheService.cs
@@ -43,7 +43,7 @@ namespace Pokedex.Api.Framework
         {
             return new MemoryCacheEntryOptions()
                         .SetAbsoluteExpiration(dateTimeProvider.GetDateTimeUtcNow().AddHours(24))
-                        .SetSlidingExpiration(new TimeSpan(0, 15, 0))
+                        //.SetSlidingExpiration(new TimeSpan(0, 15, 0)) // Removing for test/assessment of caching efficiency on Azure Web App
                         .SetPriority(CacheItemPriority.Normal);
         }
     }


### PR DESCRIPTION
To retain and align cache with third party provider threshold expiry